### PR TITLE
Fix implicit function declaration / allow compilation with modern gcc

### DIFF
--- a/torrentcheck.c
+++ b/torrentcheck.c
@@ -62,6 +62,8 @@ typedef long long INT64;
 #define DIR_SEPARATOR '/'
 #endif
 
+int beStepOver(BYTE*, int, int);
+
 typedef struct {
 	char* filePath;
 	INT64 numBytes;


### PR DESCRIPTION
Compiling with latest gcc fails, as it no longer accepts implicit function declarations:
```
torrentcheck.c:169:40: error: implicit declaration of function ‘beStepOver’ [-Wimplicit-function-declaration]
  169 |                         benstrOffset = beStepOver(benstr,benstrLen,benstrOffset);
      |                                        ^~~~~~~~~~
```

The problem is that the function beStepOver is used before it is defined.

This PR adds a function declaration at the top of the file, allowing compilation again with modern gcc versions.