### PR TITLE
Add prototype to avoid gcc warning / error.

### DIFF
--- a/torrentcheck.c
+++ b/torrentcheck.c
@@ -147,6 +147,7 @@ int beParseString(BYTE* benstr,int benstrLen,int benstrOffset,BYTE** stringBegin
 //	return (benstrOffset);
 //}
 
+int beStepOver(BYTE* benstr,int benstrLen,int benstrOffset);
 
 // Return offset of an element in a dict, or -1 if not found
 // dictKey is a null-terminated string


### PR DESCRIPTION
```
torrentcheck.c:169:40: error: implicit declaration of function ‘beStepOver’ [-Wimplicit-function-declaration]             
```

when compiling with 

```
gcc (SUSE Linux) 14.2.1 20241007 [revision 4af44f2cf7d281f3e4f3957efce10e8b2ccb2ad3]
```

The docker file may have still worked, but I just compiled locally.

Adding the prototype was a one line fix (easy to diff) I could also have just swapped the order of a couple of your functions.